### PR TITLE
Update to use vertx 1.1.0.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,62 +1,77 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>org.vertx</groupId>
-	<artifactId>vertx-maven-plugin</artifactId>
-	<packaging>maven-plugin</packaging>
+    <groupId>org.vertx</groupId>
+    <artifactId>vertx-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
 
-	<version>1.0.2-RELEASE</version>
+    <version>1.0.3-RELEASE</version>
 
-	<name>vertx-maven-plugin</name>
-	<url>https://github.com/rhart/vertx-maven-plugin</url>
+    <name>vertx-maven-plugin</name>
+    <url>https://github.com/rhart/vertx-maven-plugin</url>
 
-	<properties>
-		<maven.version>2.2.1</maven.version>
-	</properties>
+    <properties>
+        <maven.version>2.2.1</maven.version>
+    </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-plugin-api</artifactId>
-			<version>${maven.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven.version}</version>
-		</dependency>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
-		<dependency>
-			<groupId>org.vertx</groupId>
-			<artifactId>platform</artifactId>
-			<version>1.0.0.final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.vertx</groupId>
-			<artifactId>core</artifactId>
-			<version>1.0.0.final</version>
-		</dependency>
-		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty</artifactId>
-			<version>3.4.2.Final</version>
-		</dependency>
-		<dependency>
-			<groupId>org.mozilla</groupId>
-			<artifactId>rhino</artifactId>
-			<version>1.7R3</version>
-		</dependency>
 
-		<dependency>
-			<groupId>org.codehaus.jackson</groupId>
-			<artifactId>jackson-mapper-asl</artifactId>
-			<version>1.9.4</version>
-		</dependency>
-		<dependency>
-			<groupId>org.codehaus.groovy</groupId>
-			<artifactId>groovy</artifactId>
-			<version>1.8.6</version>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-project</artifactId>
+            <version>${maven.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.vertx.java</groupId>
+            <artifactId>vertx-platform</artifactId>
+            <version>1.1.0.final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.vertx.java</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>1.1.0.final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+            <version>3.4.2.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>1.7R3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>1.8.6</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/main/java/org/vertx/maven/plugin/VertxServer.java
+++ b/src/main/java/org/vertx/maven/plugin/VertxServer.java
@@ -18,7 +18,7 @@ package org.vertx.maven.plugin;
 
 import java.util.List;
 
-import org.vertx.java.deploy.impl.cli.VertxMgr;
+import org.vertx.java.deploy.impl.cli.Starter;
 
 public class VertxServer {
 	
@@ -53,7 +53,7 @@ public class VertxServer {
 
 		@Override
 		public void run() {
-			VertxMgr.main(this.args);
+			Starter.main(this.args);
 		}
 	}
 }


### PR DESCRIPTION
HI there, the old class to start Vertx via CLI is gone and has been replaced with something called Starter in vertx 1.1.0.final. I needed this because I just updated to 1.1.0.final. 

Careful with the pom changes, I used slightly different names for my deployed vertx stuff than you did. Really the only change you need is in src/main/java/org/vertx/maven/plugin/VertxServer.java.

Thanks, by the way, for starting this project, it makes the pom much nicer looking than trying to use java:exec. 

Cheers! 
