### PR TITLE
Update to use vertx 1.2.1.final in Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>vertx-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
-    <version>1.0.3-RELEASE</version>
+    <version>1.0.4-RELEASE</version>
 
     <name>vertx-maven-plugin</name>
     <url>https://github.com/rhart/vertx-maven-plugin</url>
@@ -41,37 +41,15 @@
             <artifactId>maven-project</artifactId>
             <version>${maven.version}</version>
         </dependency>
-
         <dependency>
-            <groupId>org.vertx.java</groupId>
-            <artifactId>vertx-platform</artifactId>
-            <version>1.1.0.final</version>
-        </dependency>
+           <groupId>org.vert-x</groupId>
+           <artifactId>vertx-platform</artifactId>
+           <version>1.2.1.final</version>
+       </dependency>
         <dependency>
-            <groupId>org.vertx.java</groupId>
-            <artifactId>vertx-core</artifactId>
-            <version>1.1.0.final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
-            <version>3.4.2.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>1.7R3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.4</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy</artifactId>
-            <version>1.8.6</version>
-        </dependency>
+           <groupId>org.vert-x</groupId>
+           <artifactId>vertx-core</artifactId>
+           <version>1.2.1.final</version>
+       </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/vertx/maven/plugin/VertxServer.java
+++ b/src/main/java/org/vertx/maven/plugin/VertxServer.java
@@ -16,44 +16,36 @@ package org.vertx.maven.plugin;
  * limitations under the License.
  */
 
-import java.util.List;
-
 import org.vertx.java.deploy.impl.cli.Starter;
 
+import java.util.List;
+
 public class VertxServer {
-	
-	private static final String VERTX_RUN_COMMAND = "run";
 
-	public void run(List<String> serverArgs) {
-		this.run(serverArgs, false); 
-	}
-	
-	public void run(List<String> serverArgs, boolean daemon) {
-		serverArgs.add(0, VERTX_RUN_COMMAND);
-		
-		VertxManager managerThread = new VertxManager(serverArgs.toArray(new String[serverArgs.size()]));
-		managerThread.start();
-		if (!daemon) {
-			try {
-				managerThread.join();
-			} catch (InterruptedException e) {
-				//TODO not sure what needs to happen here yet.
-			}
-		}
-	}
-	
-	
-	private class VertxManager extends Thread {
-		
-		private String[] args;
-		
-		public VertxManager(String[] args) {
-			this.args = args;
-		}
+    private static final String VERTX_RUN_COMMAND = "run";
 
-		@Override
-		public void run() {
-			Starter.main(this.args);
-		}
-	}
+    public void run(List<String> serverArgs) {
+        this.run(serverArgs, false);
+    }
+
+    public void run(final List<String> serverArgs, boolean daemon) {
+        serverArgs.add(0, VERTX_RUN_COMMAND);
+
+        final Thread managerThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                final String[] args = serverArgs.toArray(new String[serverArgs.size()]);
+                Starter.main(args);
+            }
+        }, "Vertx Manager Thread");
+        managerThread.start();
+        if (!daemon) {
+            try {
+                managerThread.join();
+            } catch (InterruptedException e) {
+                System.err.println("Unexpected thread interupt while waiting for vertx manager thread:");
+                e.printStackTrace();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Update so it works with the official maven repository versions of vertx (1.2.1.final). 
Add an message for the interrupted exception, so if it happens at least it's known about.
Refactor anti-pattern of extending Thread.
