### PR TITLE
Allow to run with vertx 1.3.0.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.anacoders.plugins</groupId>
 	<artifactId>vertx-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.2.3.3-SNAPSHOT</version>
+	<version>1.2.4.0-RELEASE</version>
 
 	<name>vertx-maven-plugin</name>
 	<url>https://github.com/rhart/vertx-maven-plugin</url>
@@ -38,7 +38,7 @@
 
 	<properties>
 		<maven.version>2.2.1</maven.version>
-		<vertx.version>1.2.3.final</vertx.version>
+		<vertx.version>1.3.0.final</vertx.version>
 		<rhino.version>1.7R3</rhino.version>
 		<groovy.version>1.8.6</groovy.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<groupId>org.anacoders.plugins</groupId>
 	<artifactId>vertx-maven-plugin</artifactId>
 	<packaging>maven-plugin</packaging>
-	<version>1.2.3.2-SNAPSHOT</version>
+	<version>1.2.3.3-SNAPSHOT</version>
 
 	<name>vertx-maven-plugin</name>
 	<url>https://github.com/rhart/vertx-maven-plugin</url>

--- a/src/main/java/org/vertx/maven/plugin/VertxRunMojo.java
+++ b/src/main/java/org/vertx/maven/plugin/VertxRunMojo.java
@@ -89,6 +89,19 @@ public class VertxRunMojo extends AbstractMojo {
 	 */
 	private String moduleRepoUrl;
 
+    /**
+     * The host on which to run the cluster. If this is not specified, then the cluster mode
+     * will not be activated.
+ 	 * @parameter expression="${run.clusterHost}"
+     */
+    private String clusterHost;
+
+    /**
+     * The cluster port to use, if not specified the vertx default is used.
+     * @parameter expression="${run.clusterPost}"
+     */
+    private int clusterPort = -1;
+
 	/**
 	 * Determines whether the verticle is a worker verticle or not. The default
 	 * is false.
@@ -202,6 +215,16 @@ public class VertxRunMojo extends AbstractMojo {
 			args.add("-conf");
 			args.add(configFile.getAbsolutePath());
 		}
+
+        if(clusterHost != null) {
+            args.add("-cluster");
+            args.add("-cluster-host");
+         	args.add(clusterHost);
+            if(clusterPort > 0) {
+                args.add("-cluster-port");
+             	args.add(Integer.toString(clusterPort));
+            }
+        }
 
 		args.add("-instances");
 		args.add(instances.toString());

--- a/src/main/java/org/vertx/maven/plugin/VertxServer.java
+++ b/src/main/java/org/vertx/maven/plugin/VertxServer.java
@@ -41,7 +41,7 @@ public class VertxServer {
             try {
                 managerThread.join();
             } catch (InterruptedException e) {
-                System.err.println("Unexpected thread interupt while waiting for vertx manager thread:");
+                System.err.println("Unexpected thread interrupt while waiting for vertx manager thread:");
                 e.printStackTrace();
             }
         }

--- a/src/main/resources/langs.properties
+++ b/src/main/resources/langs.properties
@@ -1,0 +1,13 @@
+# Mapping between main file extensions and the verticle factory for the class
+
+java=org.vertx.java.deploy.impl.java.JavaVerticleFactory
+class=org.vertx.java.deploy.impl.java.JavaVerticleFactory
+js=org.vertx.java.deploy.impl.rhino.RhinoVerticleFactory
+coffee=org.vertx.java.deploy.impl.rhino.RhinoVerticleFactory
+rb=org.vertx.java.deploy.impl.jruby.JRubyVerticleFactory
+groovy=org.vertx.groovy.deploy.impl.groovy.GroovyVerticleFactory
+py=org.vertx.java.deploy.impl.jython.JythonVerticleFactory
+
+# Default - if none match this will be assumed
+
+default=org.vertx.java.deploy.impl.java.JavaVerticleFactory


### PR DESCRIPTION
I needed to add the langs.properties to the main classpath in order to start vertx under 1.3.0.final. 
